### PR TITLE
Add Automatic-Modules-Name

### DIFF
--- a/arpack/pom.xml
+++ b/arpack/pom.xml
@@ -41,6 +41,7 @@ information or have any questions.
 
   <properties>
     <junit.version>5.8.2</junit.version>
+    <automatic.module.name>dev.ludovic.netlib.arpack</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -42,6 +42,7 @@ information or have any questions.
   <properties>
     <jmh.version>1.35</jmh.version>
     <uberjar.name>netlib-benchmarks</uberjar.name>
+    <automatic.module.name>dev.ludovic.netlib.benchmarks</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/blas/pom.xml
+++ b/blas/pom.xml
@@ -41,6 +41,7 @@ information or have any questions.
 
   <properties>
     <junit.version>5.8.2</junit.version>
+    <automatic.module.name>dev.ludovic.netlib.blas</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/lapack/pom.xml
+++ b/lapack/pom.xml
@@ -41,6 +41,7 @@ information or have any questions.
 
   <properties>
     <junit.version>5.8.2</junit.version>
+    <automatic.module.name>dev.ludovic.netlib.lapack</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@ information or have any questions.
     <javac.target>8</javac.target>
     <jvm.modules></jvm.modules>
     <argLine></argLine>
+    <automatic.module.name>dev.ludovic.netlib</automatic.module.name>
   </properties>
 
   <profiles>
@@ -193,6 +194,13 @@ information or have any questions.
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.4</version>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
Currently, the package names are still considered unstable in an JPMS sense. Adding the package name to the MANIFEST should fix this. I ran the tests and test-compile in a local Docker container and everything seemed to work. I think this should be backwards compatible with non-JPMS uses as well, I think this is just an additional entry in the MANIFEST.

Note that this does not solve requiring `arpack.combined.all` for example for `intW`, so one still has an unstable `requires` clause in the `module-info.java`. Maybe it would make sense to wrap the helper classes from the old `arpack.combined.all` to avoid users having to explciitly requiring it?