### PR TITLE
Refine logging

### DIFF
--- a/arpack/pom.xml
+++ b/arpack/pom.xml
@@ -42,7 +42,7 @@ information or have any questions.
   <packaging>jar</packaging>
 
   <properties>
-    <junit.version>5.8.2</junit.version>
+    <junit.version>5.13.4</junit.version>
     <automatic.module.name>dev.ludovic.netlib.arpack</automatic.module.name>
   </properties>
 

--- a/arpack/src/main/java/dev/ludovic/netlib/arpack/InstanceBuilder.java
+++ b/arpack/src/main/java/dev/ludovic/netlib/arpack/InstanceBuilder.java
@@ -38,7 +38,14 @@ final class InstanceBuilder {
   static {
     nativeArpack = initializeNative();
     javaArpack = initializeJava();
-    arpack = nativeArpack != null ? nativeArpack : javaArpack;
+
+    if (nativeArpack == null) {
+      log.info("Using JavaARPACK");
+      arpack = javaArpack;
+    } else {
+      log.info("Using native ARPACK");
+      arpack = nativeArpack;
+    }
   }
 
   public static ARPACK arpack() {
@@ -49,7 +56,7 @@ final class InstanceBuilder {
     try {
       return JNIARPACK.getInstance();
     } catch (Throwable t) {
-      log.warning("Failed to load implementation from:" + JNIARPACK.class.getName());
+      log.fine("Failed to load implementation from:" + JNIARPACK.class.getName());
       return null;
     }
   }

--- a/arpack/src/main/java/dev/ludovic/netlib/arpack/JNIARPACK.java
+++ b/arpack/src/main/java/dev/ludovic/netlib/arpack/JNIARPACK.java
@@ -25,8 +25,9 @@
 
 package dev.ludovic.netlib.arpack;
 
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -55,7 +56,7 @@ final class JNIARPACK extends AbstractARPACK implements NativeARPACK {
                   StandardCopyOption.REPLACE_EXISTING);
       temp.toFile().deleteOnExit();
     } catch (IOException e) {
-      throw new RuntimeException("Unable to load native implementation", e);
+      throw new UncheckedIOException("Unable to load native implementation", e);
     }
 
     System.load(temp.toString());

--- a/blas/pom.xml
+++ b/blas/pom.xml
@@ -42,7 +42,7 @@ information or have any questions.
   <packaging>jar</packaging>
 
   <properties>
-    <junit.version>5.8.2</junit.version>
+    <junit.version>5.13.4</junit.version>
     <automatic.module.name>dev.ludovic.netlib.blas</automatic.module.name>
   </properties>
 

--- a/blas/src/main/java/dev/ludovic/netlib/blas/JNIBLAS.java
+++ b/blas/src/main/java/dev/ludovic/netlib/blas/JNIBLAS.java
@@ -25,8 +25,9 @@
 
 package dev.ludovic.netlib.blas;
 
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -55,7 +56,7 @@ final class JNIBLAS extends AbstractBLAS implements NativeBLAS {
                   StandardCopyOption.REPLACE_EXISTING);
       temp.toFile().deleteOnExit();
     } catch (IOException e) {
-      throw new RuntimeException("Unable to load native implementation", e);
+      throw new UncheckedIOException("Unable to load native implementation", e);
     }
 
     System.load(temp.toString());

--- a/lapack/pom.xml
+++ b/lapack/pom.xml
@@ -42,7 +42,7 @@ information or have any questions.
   <packaging>jar</packaging>
 
   <properties>
-    <junit.version>5.8.2</junit.version>
+    <junit.version>5.13.4</junit.version>
     <automatic.module.name>dev.ludovic.netlib.lapack</automatic.module.name>
   </properties>
 

--- a/lapack/src/main/java/dev/ludovic/netlib/lapack/InstanceBuilder.java
+++ b/lapack/src/main/java/dev/ludovic/netlib/lapack/InstanceBuilder.java
@@ -38,7 +38,14 @@ final class InstanceBuilder {
   static {
     nativeLapack = initializeNative();
     javaLapack = initializeJava();
-    lapack = nativeLapack != null ? nativeLapack : javaLapack;
+
+    if (nativeLapack == null) {
+      log.info("Using JavaLAPACK");
+      lapack = javaLapack;
+    } else {
+      log.info("Using native LAPACK");
+      lapack = nativeLapack;
+    }
   }
 
   public static LAPACK lapack() {
@@ -49,14 +56,14 @@ final class InstanceBuilder {
     try {
       return JNILAPACK.getInstance();
     } catch (Throwable t) {
-      log.warning("Failed to load implementation from:" + JNILAPACK.class.getName());
+      log.fine("Failed to load implementation from:" + JNILAPACK.class.getName());
       return null;
     }
   }
 
   public static NativeLAPACK nativeLapack() {
     if (nativeLapack == null) {
-      throw new RuntimeException("Unable to load native implementation");
+      throw new RuntimeException("Unable to load native LAPACK implementation");
     }
     return nativeLapack;
   }

--- a/lapack/src/main/java/dev/ludovic/netlib/lapack/JNILAPACK.java
+++ b/lapack/src/main/java/dev/ludovic/netlib/lapack/JNILAPACK.java
@@ -26,6 +26,7 @@
 package dev.ludovic.netlib.lapack;
 
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -55,10 +56,11 @@ final class JNILAPACK extends AbstractLAPACK implements NativeLAPACK {
                   StandardCopyOption.REPLACE_EXISTING);
       temp.toFile().deleteOnExit();
     } catch (IOException e) {
-      throw new RuntimeException("Unable to load native implementation", e);
+      throw new UncheckedIOException("Unable to load native implementation", e);
     }
 
-    System.load(temp.toString());}
+    System.load(temp.toString());
+  }
 
   public static NativeLAPACK getInstance() {
     return instance;


### PR DESCRIPTION
* Refines logging, i.e., it states what has been loaded and shows the failure of loading e.g. JNIBLAS only at a lower logging level as this failure does not hamper correct operation.
* Bump JUnit version.
* Use `UncheckedIOException` instead of `RuntimeException` for a caught and rethrown `IOException`.

Cf. #26 